### PR TITLE
Fixed wrong WebIDL syntax on CertificatePrincipal Interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,9 +200,10 @@ interface Certificate {
 		<section id='certificateprincipal-interface'>
 			<h3>CertificatePrincipal Interface</h3>			
 			<pre class="idl">
-Interface CertificatePrincipal {
+[SecureContext, Exposed=Window]
+interface CertificatePrincipal {
     readonly attribute DOMString distinguishedNames;
-} 
+};
 			</pre>
 			<section id='certificateprincipal-interface-description'>
 				<h3>Description</h3>			


### PR DESCRIPTION
- Fixed wrong WebIDL syntax on CertificatePrincipal Interface